### PR TITLE
Change license from MIT to BSD 3-Clause

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
-# Copyright (c) Victor Derks.
-# SPDX-License-Identifier: MIT
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
 
 BasedOnStyle: LLVM
 Language: Cpp

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # The approach for using clang tidy is to enable all warnings unless it adds no practical value to the Netpbm WIC Codec project
 # Having all warnings enables helps to find problems when new code is added to the project. Some warnings are however

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Copyright (c) Victor Derks.
-# SPDX-License-Identifier: MIT
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
 
 root = true
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Copyright (c) Victor Derks
-# SPDX-License-Identifier: MIT
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Set default behavior to automatically normalize line endings.
 * text=auto

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
-# Copyright (c) Victor Derks.
-# SPDX-License-Identifier: MIT
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
 
 version: 2
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,5 +1,5 @@
-# Copyright (c) Victor Derks.
-# SPDX-License-Identifier: MIT
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
 
 name: Build and test
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Copyright (c) Victor Derks.
-# SPDX-License-Identifier: MIT
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
 
 bin/
 .vscode/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,21 +1,29 @@
-MIT License
+BSD 3-Clause License
 
-Copyright (c) 2021 Victor Derks
+Copyright (c) 2021 Team CharLS
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cpp.hint
+++ b/cpp.hint
@@ -1,3 +1,6 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
 // Hint files help the Visual Studio IDE interpret Visual C++ identifiers
 // such as names of functions and macros.
 // For more information see https://go.microsoft.com/fwlink/?linkid=865984

--- a/default.ruleset
+++ b/default.ruleset
@@ -3,12 +3,10 @@
   <IncludeAll Action="Error" />
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
     <Rule Id="C26429" Action="None" />
-    <Rule Id="C26435" Action="None" />
     <Rule Id="C26446" Action="None" />
     <Rule Id="C26459" Action="None" />
     <Rule Id="C26466" Action="None" />
     <Rule Id="C26472" Action="None" />
-    <Rule Id="C26478" Action="None" />
     <Rule Id="C26481" Action="None" />
     <Rule Id="C26482" Action="None" />
     <Rule Id="C26485" Action="None" />
@@ -16,6 +14,5 @@
     <Rule Id="C26491" Action="None" />
     <Rule Id="C26494" Action="None" />
     <Rule Id="C26821" Action="None" />
-    <Rule Id="C28290" Action="None" />
   </Rules>
 </RuleSet>

--- a/default.ruleset.md
+++ b/default.ruleset.md
@@ -11,9 +11,6 @@ Most of these rules\warning are based on the C++ Core Guidelines.
 - C26429: Use a not_null to indicate that "null" is not a valid value  
 **Rationale**: Prefast attributes (\_In_, etc.) are better than gsl::not_null.
 
-- C26435: Function '' should specify exactly one of 'virtual', 'override', or 'final' (c.128).
-**Rationale**: False warning in Visual Studio 2022 Version 17.5.0 Preview 1.0.
-
 - C26446: Prefer to use gsl::at() instead of unchecked subscript operator.  
 **Rationale**: gsl:at() cannot be used as gsl project is by design not included. MSVC STL in debug mode already checks access.
 
@@ -25,9 +22,6 @@ Most of these rules\warning are based on the C++ Core Guidelines.
 
 - C26472: Don't use static_cast for arithmetic conversions  
 **Rationale**: can only be solved with gsl::narrow_cast
-
-- C26478: Don't use std::move on constant variables. (es.56).
-**Rationale**: false warnings (VS 2022 17.7.0 Preview 3.0)
 
 - C26481: Do not pass an array as a single pointer.  
 **Rationale**: gsl::span is not available.
@@ -45,8 +39,5 @@ Most of these rules\warning are based on the C++ Core Guidelines.
 **Rationale**: many false warnings due to output parameters. Other analyzers are better
 as they check if the variable is used before initialized.
 
-- C26821: For '', consider using gsl::span instead of std::span to guarantee runtime bounds safety (gsl.view)
+- C26821: For '', consider using gsl::span instead of std::span to guarantee runtime bounds safety (gsl.view)  
 **Rationale**: preference is to use types from the std namespace.
-
-- C28290: The annotation for function '{ctor}' contains more Externals than the actual number of parameters.
-**Rationale**: false warnings (VS 2022 17.4.0)

--- a/netpbm-wic-codec.sln.DotSettings
+++ b/netpbm-wic-codec.sln.DotSettings
@@ -1,8 +1,10 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyBugproneBranchClone/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyBugproneEmptyCatch/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClassCanBeFinal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=anymap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bugprone/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=charls/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CLSID/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cppcoreguidelines/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=defacto/@EntryIndexedValue">True</s:Boolean>

--- a/src/buffered_stream_reader.cpp
+++ b/src/buffered_stream_reader.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -8,7 +8,7 @@ module;
 
 module buffered_stream_reader;
 
-import <win.h>;
+import <win.hpp>;
 
 import errors;
 import util;

--- a/src/buffered_stream_reader.ixx
+++ b/src/buffered_stream_reader.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -7,7 +7,7 @@ module;
 
 export module buffered_stream_reader;
 
-import <win.h>;
+import <win.hpp>;
 import std;
 import winrt;
 

--- a/src/class_factory.ixx
+++ b/src/class_factory.ixx
@@ -1,9 +1,9 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 export module class_factory;
 
-import <win.h>;
+import <win.hpp>;
 import winrt;
 
 import errors;

--- a/src/dll_main.cpp
+++ b/src/dll_main.cpp
@@ -1,11 +1,11 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "macros.hpp"
-#include "version.h"
+#include "version.hpp"
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import winrt;
 
 import netpbm_bitmap_decoder;
@@ -30,7 +30,7 @@ void register_general_decoder_settings(const GUID& class_id, const GUID& wic_cat
 {
     const wstring sub_key = LR"(SOFTWARE\Classes\CLSID\)" + guid_to_string(class_id);
     registry::set_value(sub_key, L"ArbitrationPriority", 10);
-    registry::set_value(sub_key, L"Author", L"Victor Derks");
+    registry::set_value(sub_key, L"Author", L"Team CharLS");
     registry::set_value(sub_key, L"ColorManagementVersion", L"1.0.0.0");
     registry::set_value(sub_key, L"ContainerFormat", guid_to_string(id::container_format_netpbm).c_str());
     registry::set_value(sub_key, L"Description", L"Netpbm Codec");
@@ -42,7 +42,7 @@ void register_general_decoder_settings(const GUID& class_id, const GUID& wic_cat
     registry::set_value(sub_key, L"SupportChromaKey", 0U);
     registry::set_value(sub_key, L"SupportLossless", 1U);
     registry::set_value(sub_key, L"SupportMultiframe", 0U);
-    registry::set_value(sub_key, L"Vendor", guid_to_string(id::vendor_victor_derks).c_str());
+    registry::set_value(sub_key, L"Vendor", guid_to_string(id::vendor_team_charls).c_str());
     registry::set_value(sub_key, L"Version", VERSION);
 
     const wstring formats_sub_key{sub_key + LR"(\Formats\)"};
@@ -103,7 +103,7 @@ void register_decoder()
 {
     array formats{&GUID_WICPixelFormat2bppGray, &GUID_WICPixelFormat4bppGray, &GUID_WICPixelFormat8bppGray,
                   &GUID_WICPixelFormat16bppGray, &GUID_WICPixelFormat24bppRGB};
-    register_general_decoder_settings(id::netpbm_decoder, CATID_WICBitmapDecoders, L"Netpbm Decoder", formats);
+    register_general_decoder_settings(id::netpbm_decoder, CATID_WICBitmapDecoders, L"Team CharLS Netpbm Decoder", formats);
 
     const wstring sub_key{LR"(SOFTWARE\Classes\CLSID\)" + guid_to_string(id::netpbm_decoder)};
 
@@ -200,7 +200,7 @@ HRESULT __stdcall DllUnregisterServer()
 try
 {
     TRACE("netpbm-wic-codec::DllUnregisterServer\n");
-    // Note: keep the .pgm file registration intact.
+    // Note: keep the file registrations intact.
     return unregister(id::netpbm_decoder, CATID_WICBitmapDecoders);
 }
 catch (...)

--- a/src/errors.ixx
+++ b/src/errors.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -7,7 +7,7 @@ module;
 
 export module errors;
 
-import <win.h>;
+import <win.hpp>;
 
 export {
 

--- a/src/guids.ixx
+++ b/src/guids.ixx
@@ -1,9 +1,9 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 export module guids;
 
-import <win.h>;
+import <win.hpp>;
 
 export namespace id {
 
@@ -13,7 +13,7 @@ constexpr GUID netpbm_decoder{0x6891bbe, 0xcc02, 0x4bb2, {0x9c, 0xf0, 0x30, 0x3f
 // {70ab66f5-cd48-43a1-aa29-10131b7f4ff1}
 constexpr GUID container_format_netpbm{0x70ab66f5, 0xcd48, 0x43a1, {0xaa, 0x29, 0x10, 0x13, 0x1b, 0x7f, 0x4f, 0xf1}};
 
-// {87a8e9f4-8aac-4667-bcfd-56535c80a269}
-constexpr GUID vendor_victor_derks{0x87a8e9f4, 0x8aac, 0x4667, {0xbc, 0xfd, 0x56, 0x53, 0x5c, 0x80, 0xa2, 0x69}};
+// {8adbe21c-a720-424e-b238-45ad1052b98c}
+constexpr GUID vendor_team_charls{0x8adbe21c, 0xa720, 0x424e, {0xb2, 0x38, 0x45, 0xad, 0x10, 0x52, 0xb9, 0x8c}};
 
 }

--- a/src/intellisense.hpp
+++ b/src/intellisense.hpp
@@ -1,10 +1,12 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-// Include explicit headers as workaround that IntelliSense in VS 2022 17.12 fails to parse #import <win.h>
+// Include explicit headers as workaround that IntelliSense (VS 2022 17.12)
+// and ReSharper (2024.2.5) fail to parse #import <win.hpp>
 #if defined(__INTELLISENSE__) || defined(__RESHARPER__)
+// ReSharper disable once CppInconsistentNaming
 #define _AMD64_
 #include <combaseapi.h>
 #include <libloaderapi.h>

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 

--- a/src/netpbm-wic-codec.def
+++ b/src/netpbm-wic-codec.def
@@ -1,3 +1,6 @@
+; Copyright (c) Team CharLS.
+; SPDX-License-Identifier: BSD-3-Clause
+
 EXPORTS
     DllCanUnloadNow     PRIVATE
     DllGetClassObject   PRIVATE

--- a/src/netpbm-wic-codec.rc
+++ b/src/netpbm-wic-codec.rc
@@ -1,9 +1,9 @@
-// Copyright (c) Victor Derks
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma code_page(65001)
 
-#include "version.h"
+#include "version.hpp"
 
 #include <winres.h>
 
@@ -13,10 +13,10 @@ VS_VERSION_INFO VERSIONINFO
  FILEVERSION VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, 0
  PRODUCTVERSION VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, 0
  FILEFLAGSMASK 0x3fL
-#ifdef _DEBUG
- FILEFLAGS 0x1L
-#else
+#ifdef NDEBUG
  FILEFLAGS 0x0L
+#else
+ FILEFLAGS 0x1L
 #endif
  FILEOS 0x40004L
  FILETYPE 0x2L
@@ -26,11 +26,11 @@ BEGIN
     BEGIN
         BLOCK "000004b0"
         BEGIN
-            VALUE "CompanyName", "Victor Derks"
+            VALUE "CompanyName", "Team CharLS"
             VALUE "FileDescription", L"Netpbm WIC codec"
             VALUE "FileVersion", VERSION
             VALUE "InternalName", L"netpbm-wic-codec.dll"
-            VALUE "LegalCopyright", L"Copyright (c) Victor Derks"
+            VALUE "LegalCopyright", L"Copyright (c) Team CharLS"
             VALUE "OriginalFilename", L"netpbm-wic-codec.dll"
             VALUE "ProductName", L"Netpbm WIC codec"
             VALUE "ProductVersion", VERSION

--- a/src/netpbm-wic-codec.vcxproj
+++ b/src/netpbm-wic-codec.vcxproj
@@ -112,9 +112,6 @@
   <ItemDefinitionGroup Condition="'$(Platform)'=='ARM64'">
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -139,7 +136,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -150,9 +146,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -194,7 +187,7 @@
   <ItemGroup>
     <ClInclude Include="intellisense.hpp" />
     <ClInclude Include="macros.hpp" />
-    <ClInclude Include="version.h" />
+    <ClInclude Include="version.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="buffered_stream_reader.cpp" />

--- a/src/netpbm-wic-codec.vcxproj.filters
+++ b/src/netpbm-wic-codec.vcxproj.filters
@@ -15,7 +15,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="version.h">
+    <ClInclude Include="version.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="macros.hpp">

--- a/src/netpbm_bitmap_decoder.cpp
+++ b/src/netpbm_bitmap_decoder.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -8,7 +8,7 @@ module;
 module netpbm_bitmap_decoder;
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import winrt;
 
 import class_factory;
@@ -18,8 +18,8 @@ import guids;
 import netpbm_bitmap_frame_decode;
 import util;
 
-using std::uint32_t;
 using std::scoped_lock;
+using std::uint32_t;
 using winrt::check_hresult;
 using winrt::com_ptr;
 using winrt::to_hresult;
@@ -138,7 +138,7 @@ struct netpbm_bitmap_decoder : winrt::implements<netpbm_bitmap_decoder, IWICBitm
 
     HRESULT __stdcall GetColorContexts([[maybe_unused]] const uint32_t count,
                                        [[maybe_unused]] IWICColorContext** color_contexts,
-                                       [[maybe_unused]] uint32_t* actual_count) noexcept override
+                                       uint32_t* actual_count) noexcept override
     try
     {
         TRACE("{} netpbm_bitmap_decoder::GetColorContexts (always 0), count={}, color_contexts address={}, actual_count "

--- a/src/netpbm_bitmap_decoder.ixx
+++ b/src/netpbm_bitmap_decoder.ixx
@@ -1,8 +1,8 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 export module netpbm_bitmap_decoder;
 
-import <win.h>;
+import <win.hpp>;
 
 export void create_netpbm_bitmap_decoder_factory(GUID const& interface_id, void** result);

--- a/src/netpbm_bitmap_frame_decode.cpp
+++ b/src/netpbm_bitmap_frame_decode.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -8,7 +8,7 @@ module;
 module netpbm_bitmap_frame_decode;
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import winrt;
 
 import errors;

--- a/src/netpbm_bitmap_frame_decode.ixx
+++ b/src/netpbm_bitmap_frame_decode.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -8,7 +8,7 @@ module;
 export module netpbm_bitmap_frame_decode;
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import winrt;
 
 using std::uint32_t;

--- a/src/pnm_header.ixx
+++ b/src/pnm_header.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -8,7 +8,7 @@ module;
 export module pnm_header;
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import winrt;
 
 import buffered_stream_reader;
@@ -55,7 +55,7 @@ export struct pnm_header
         char magic[2];
         ULONG bytesRead;
 
-        streamReader.read_bytes((BYTE*)&magic, sizeof(magic), &bytesRead);
+        streamReader.read_bytes(&magic, sizeof(magic), &bytesRead);
         if (bytesRead != sizeof(magic))
             throw_hresult(wincodec::error_bad_header);
 

--- a/src/registry.ixx
+++ b/src/registry.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -8,7 +8,7 @@ module;
 export module registry;
 
 import std;
-import <win.h>;
+import <win.hpp>;
 
 import errors;
 import winrt;

--- a/src/util.ixx
+++ b/src/util.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -8,7 +8,7 @@ module;
 export module util;
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import winrt;
 
 import errors;

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 

--- a/src/winrt.ixx
+++ b/src/winrt.ixx
@@ -1,8 +1,9 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
+// ReSharper disable once CppInconsistentNaming
 #define _CRT_MEMCPY_S_INLINE inline
 
 // ReSharper disable once CppUnusedIncludeDirective

--- a/std-header-units/generate_header_units.cpp
+++ b/std-header-units/generate_header_units.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
-import "win.h";
+import "win.hpp";

--- a/std-header-units/std-header-units.vcxproj
+++ b/std-header-units/std-header-units.vcxproj
@@ -102,7 +102,6 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies>
     </ClCompile>
     <Link>
@@ -124,7 +123,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies>
     </ClCompile>
     <Link>
@@ -133,7 +131,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies>
     </ClCompile>
     <Link>
@@ -170,7 +167,7 @@
     <ClCompile Include="generate_header_units.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="win.h" />
+    <ClInclude Include="win.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/std-header-units/std-header-units.vcxproj.filters
+++ b/std-header-units/std-header-units.vcxproj.filters
@@ -16,7 +16,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="win.h">
+    <ClInclude Include="win.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/std-header-units/win.hpp
+++ b/std-header-units/win.hpp
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 

--- a/test/buffered_stream_reader_test.cpp
+++ b/test/buffered_stream_reader_test.cpp
@@ -1,11 +1,11 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "intellisense.hpp"
-#include "util.hpp"
+#include "cpp_unit_test.hpp"
 
 import std;
-import "win.h";
+import "win.hpp";
 import test.winrt;
 
 import buffered_stream_reader;
@@ -51,13 +51,13 @@ public:
         source.insert(source.end(), str1.begin(), str1.end());
         buffered_stream_reader reader(create_memory_stream(source).get());
 
-        auto value = reader.read_int();
+        const auto value = reader.read_int();
 
         Assert::AreEqual(256U, value);
     }
 
 private:
-    com_ptr<IStream> create_memory_stream(span<char> source)
+    static com_ptr<IStream> create_memory_stream(span<char> source)
     {
         com_ptr<IStream> stream;
         stream.attach(SHCreateMemStream(reinterpret_cast<BYTE*>(source.data()), static_cast<UINT>(source.size())));

--- a/test/codec_factory.ixx
+++ b/test/codec_factory.ixx
@@ -1,27 +1,30 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
 #include "intellisense.hpp"
 
-export module factory;
+export module codec_factory;
 
-import <win.h>;
+import <win.hpp>;
 import test.winrt;
 
 export constexpr GUID net_pbm_decoder_class_id{0x6891bbe, 0xcc02, 0x4bb2, {0x9c, 0xf0, 0x30, 0x3f, 0xc4, 0xe6, 0x68, 0xc3}};
 
-export class factory final
+/// <summary>
+/// Helper class that provides methods to create COM objects without registry registration.
+/// </summary>
+export class codec_factory final
 {
 public:
-    factory() noexcept(false) : library_{LoadLibrary(L"netpbm-wic-codec.dll")}
+    codec_factory() noexcept(false) : library_{LoadLibrary(L"netpbm-wic-codec.dll")}
     {
         if (!library_)
             winrt::throw_last_error();
     }
 
-    ~factory()
+    ~codec_factory()
     {
         if (library_)
         {
@@ -29,10 +32,10 @@ public:
         }
     }
 
-    factory(const factory&) = delete;
-    factory(factory&&) = delete;
-    factory& operator=(const factory&) = delete;
-    factory& operator=(factory&&) = delete;
+    codec_factory(const codec_factory&) = delete;
+    codec_factory(codec_factory&&) = delete;
+    codec_factory& operator=(const codec_factory&) = delete;
+    codec_factory& operator=(codec_factory&&) = delete;
 
     [[nodiscard]] winrt::com_ptr<IWICBitmapDecoder> create_decoder() const
     {

--- a/test/cpp_unit_test.hpp
+++ b/test/cpp_unit_test.hpp
@@ -1,9 +1,9 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-// Workaround for MSVC defect developercommunity.visualstudio.com/t/IntelliSense-error-E3344-due-to-CppUnit/10185254
+// Workaround for MSVC defect https://developercommunity.visualstudio.com/t/IntelliSense-error-E3344-due-to-CppUnit/10185254
 #ifdef __INTELLISENSE__
 inline void __stdcall Internal_SetExpectedExceptionMessage(const unsigned short* /*message*/)
 {

--- a/test/dll_main_test.cpp
+++ b/test/dll_main_test.cpp
@@ -1,13 +1,14 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
-#include "util.hpp"
+#include "macros.hpp"
+#include "cpp_unit_test.hpp"
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import test.winrt;
 import test.errors;
-import factory;
+import codec_factory;
 
 using namespace winrt;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -60,7 +61,7 @@ public:
 
     TEST_METHOD(marked_for_self_registration) // NOLINT
     {
-        const wchar_t dll_name[]{L"netpbm-wic-codec.dll"};
+        constexpr wchar_t dll_name[]{L"netpbm-wic-codec.dll"};
         DWORD not_used;
         const DWORD size{GetFileVersionInfoSizeEx(FILE_VER_GET_NEUTRAL, dll_name, &not_used)};
         Assert::IsTrue(size != 0);
@@ -76,5 +77,5 @@ public:
     }
 
 private:
-    factory factory_;
+    codec_factory factory_;
 };

--- a/test/intellisense.hpp
+++ b/test/intellisense.hpp
@@ -1,10 +1,11 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 
-// Include explicit headers as workaround that IntelliSense in VS 2022 17.12 fails to parse #import <win.h>
-#ifdef __INTELLISENSE__
+// Include explicit headers as workaround that IntelliSense (VS 2022 17.12)
+// and ReSharper (2024.2.5) fail to parse #import <win.hpp>
+#if defined(__INTELLISENSE__) || defined(__RESHARPER__)
 #define _AMD64_
 #include <combaseapi.h>
 #include <libloaderapi.h>

--- a/test/macros.hpp
+++ b/test/macros.hpp
@@ -1,14 +1,12 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
-
-#include "cpp_unit_test.hpp"
 
 #define SUPPRESS_WARNING_NEXT_LINE(x) \
     __pragma(warning(suppress \
                      : x)) // NOLINT(misc-macro-parentheses, bugprone-macro-parentheses, cppcoreguidelines-macro-usage)
 
-// The static analyzer detects that a invalid argument is passed, for unit testing
+// The static analyzer detects that an invalid argument is passed, for unit testing
 // this warning must be suppressed.
 #define SUPPRESS_WARNING_6387_INVALID_ARGUMENT_NEXT_LINE SUPPRESS_WARNING_NEXT_LINE(6387)

--- a/test/netpbm_bitmap_decoder_test.cpp
+++ b/test/netpbm_bitmap_decoder_test.cpp
@@ -1,16 +1,17 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
-#include "util.hpp"
+#include "macros.hpp"
 #include "intellisense.hpp"
+#include "cpp_unit_test.hpp"
 
-import <win.h>;
+import <win.hpp>;
 import test.winrt;
 
 import test.errors;
 import test.stream;
 import test.util;
-import factory;
+import codec_factory;
 
 using namespace winrt;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -26,7 +27,7 @@ public:
     TEST_METHOD(GetContainerFormat) // NOLINT
     {
         GUID container_format;
-        const auto result{factory_.create_decoder()->GetContainerFormat(&container_format)};
+        const auto result{codec_factory_.create_decoder()->GetContainerFormat(&container_format)};
 
         Assert::AreEqual(error_ok, result);
         Assert::IsTrue(container_format_netpbm == container_format);
@@ -35,14 +36,14 @@ public:
     TEST_METHOD(GetContainerFormat_with_nullptr) // NOLINT
     {
         SUPPRESS_WARNING_6387_INVALID_ARGUMENT_NEXT_LINE
-        const auto result{factory_.create_decoder()->GetContainerFormat(nullptr)};
+        const auto result{codec_factory_.create_decoder()->GetContainerFormat(nullptr)};
 
         Assert::IsTrue(failed(result));
     }
 
     TEST_METHOD(GetDecoderInfo) // NOLINT
     {
-        com_ptr<IWICBitmapDecoder> decoder = factory_.create_decoder();
+        const com_ptr decoder{codec_factory_.create_decoder()};
 
         com_ptr<IWICBitmapDecoderInfo> decoder_info;
         const auto result{decoder->GetDecoderInfo(decoder_info.put())};
@@ -61,7 +62,7 @@ public:
     TEST_METHOD(GetDecoderInfo_with_nullptr) // NOLINT
     {
         SUPPRESS_WARNING_6387_INVALID_ARGUMENT_NEXT_LINE
-        const auto result{factory_.create_decoder()->GetDecoderInfo(nullptr)};
+        const auto result{codec_factory_.create_decoder()->GetDecoderInfo(nullptr)};
 
         Assert::IsTrue(failed(result));
     }
@@ -69,7 +70,7 @@ public:
     TEST_METHOD(CopyPalette) // NOLINT
     {
         const com_ptr<IWICPalette> palette;
-        const auto result{factory_.create_decoder()->CopyPalette(palette.get())};
+        const auto result{codec_factory_.create_decoder()->CopyPalette(palette.get())};
 
         Assert::AreEqual(wincodec::error_palette_unavailable, result);
     }
@@ -77,7 +78,7 @@ public:
     TEST_METHOD(GetMetadataQueryReader) // NOLINT
     {
         com_ptr<IWICMetadataQueryReader> metadata_query_reader;
-        const auto result{factory_.create_decoder()->GetMetadataQueryReader(metadata_query_reader.put())};
+        const auto result{codec_factory_.create_decoder()->GetMetadataQueryReader(metadata_query_reader.put())};
 
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
@@ -85,7 +86,7 @@ public:
     TEST_METHOD(GetPreview) // NOLINT
     {
         com_ptr<IWICBitmapSource> bitmap_source;
-        const auto result{factory_.create_decoder()->GetPreview(bitmap_source.put())};
+        const auto result{codec_factory_.create_decoder()->GetPreview(bitmap_source.put())};
 
         Assert::AreEqual(wincodec::error_unsupported_operation, result);
     }
@@ -94,7 +95,7 @@ public:
     {
         com_ptr<IWICColorContext> color_contexts;
         uint32_t actual_count;
-        const auto result{factory_.create_decoder()->GetColorContexts(1, color_contexts.put(), &actual_count)};
+        const auto result{codec_factory_.create_decoder()->GetColorContexts(1, color_contexts.put(), &actual_count)};
 
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(0U, actual_count);
@@ -103,7 +104,7 @@ public:
     TEST_METHOD(GetThumbnail) // NOLINT
     {
         com_ptr<IWICBitmapSource> bitmap_source;
-        const auto result{factory_.create_decoder()->GetThumbnail(bitmap_source.put())};
+        const auto result{codec_factory_.create_decoder()->GetThumbnail(bitmap_source.put())};
 
         Assert::AreEqual(wincodec::error_codec_no_thumbnail, result);
     }
@@ -111,7 +112,7 @@ public:
     TEST_METHOD(GetFrameCount) // NOLINT
     {
         uint32_t frame_count;
-        const auto result{factory_.create_decoder()->GetFrameCount(&frame_count)};
+        const auto result{codec_factory_.create_decoder()->GetFrameCount(&frame_count)};
 
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(1U, frame_count);
@@ -120,7 +121,7 @@ public:
     TEST_METHOD(GetFrameCount_count_parameter_is_null) // NOLINT
     {
         SUPPRESS_WARNING_6387_INVALID_ARGUMENT_NEXT_LINE
-        const auto result{factory_.create_decoder()->GetFrameCount(nullptr)};
+        const auto result{codec_factory_.create_decoder()->GetFrameCount(nullptr)};
 
         Assert::AreEqual(error_pointer, result);
     }
@@ -131,7 +132,7 @@ public:
         stream.attach(SHCreateMemStream(nullptr, 0));
 
         DWORD capability;
-        const auto result{factory_.create_decoder()->QueryCapability(stream.get(), &capability)};
+        const auto result{codec_factory_.create_decoder()->QueryCapability(stream.get(), &capability)};
 
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(0UL, capability);
@@ -140,7 +141,7 @@ public:
     TEST_METHOD(QueryCapability_stream_argument_null) // NOLINT
     {
         DWORD capability;
-        const auto result{factory_.create_decoder()->QueryCapability(nullptr, &capability)};
+        const auto result{codec_factory_.create_decoder()->QueryCapability(nullptr, &capability)};
 
         Assert::AreEqual(error_invalid_argument, result);
     }
@@ -151,7 +152,7 @@ public:
         stream.attach(SHCreateMemStream(nullptr, 0));
 
         SUPPRESS_WARNING_6387_INVALID_ARGUMENT_NEXT_LINE
-        const auto result{factory_.create_decoder()->QueryCapability(stream.get(), nullptr)};
+        const auto result{codec_factory_.create_decoder()->QueryCapability(stream.get(), nullptr)};
 
         Assert::AreEqual(error_pointer, result);
     }
@@ -162,7 +163,7 @@ public:
         check_hresult(
             SHCreateStreamOnFileEx(L"tulips-gray-8bit-512-512.pgm", STGM_READ | STGM_SHARE_DENY_WRITE, 0, false, nullptr, stream.put()));
         DWORD capability;
-        const auto result{factory_.create_decoder()->QueryCapability(stream.get(), &capability)};
+        const auto result{codec_factory_.create_decoder()->QueryCapability(stream.get(), &capability)};
 
         Assert::AreEqual(error_ok, result);
         Assert::AreEqual(static_cast<DWORD>(WICBitmapDecoderCapabilityCanDecodeAllImages), capability);
@@ -170,30 +171,30 @@ public:
 
     TEST_METHOD(QueryCapability_read_error_on_stream) // NOLINT
     {
-        com_ptr<IStream> stream{winrt::make<test_stream>(true, 2)};
+        const com_ptr stream{winrt::make<test_stream>(true, 2)};
 
         DWORD capability;
-        const auto result = factory_.create_decoder()->QueryCapability(stream.get(), &capability);
+        const auto result = codec_factory_.create_decoder()->QueryCapability(stream.get(), &capability);
 
         Assert::IsTrue(failed(result));
     }
 
     TEST_METHOD(QueryCapability_seek_error_on_stream) // NOLINT
     {
-        com_ptr<IStream> stream{winrt::make<test_stream>(false, 1)};
+        const com_ptr stream{winrt::make<test_stream>(false, 1)};
 
         DWORD capability;
-        const auto result = factory_.create_decoder()->QueryCapability(stream.get(), &capability);
+        const auto result = codec_factory_.create_decoder()->QueryCapability(stream.get(), &capability);
 
         Assert::IsTrue(failed(result));
     }
 
     TEST_METHOD(QueryCapability_seek_error_on_stream_reset) // NOLINT
     {
-        com_ptr<IStream> stream{winrt::make<test_stream>(false, 2)};
+        const com_ptr stream{winrt::make<test_stream>(false, 2)};
 
         DWORD capability;
-        const auto result = factory_.create_decoder()->QueryCapability(stream.get(), &capability);
+        const auto result = codec_factory_.create_decoder()->QueryCapability(stream.get(), &capability);
 
         Assert::IsTrue(failed(result));
     }
@@ -203,7 +204,7 @@ public:
         com_ptr<IStream> stream;
         stream.attach(SHCreateMemStream(nullptr, 0));
 
-        const auto result{factory_.create_decoder()->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
+        const auto result{codec_factory_.create_decoder()->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_ok, result);
     }
 
@@ -212,7 +213,7 @@ public:
         com_ptr<IStream> stream;
         stream.attach(SHCreateMemStream(nullptr, 0));
 
-        const auto result{factory_.create_decoder()->Initialize(stream.get(), WICDecodeMetadataCacheOnLoad)};
+        const auto result{codec_factory_.create_decoder()->Initialize(stream.get(), WICDecodeMetadataCacheOnLoad)};
         Assert::AreEqual(error_ok, result);
     }
 
@@ -221,7 +222,7 @@ public:
         com_ptr<IStream> stream;
         stream.attach(SHCreateMemStream(nullptr, 0));
 
-        com_ptr<IWICBitmapDecoder> decoder = factory_.create_decoder();
+        const com_ptr decoder{codec_factory_.create_decoder()};
         auto result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_ok, result);
 
@@ -234,7 +235,7 @@ public:
         com_ptr<IStream> stream;
         stream.attach(SHCreateMemStream(nullptr, 0));
 
-        const auto result{factory_.create_decoder()->Initialize(stream.get(), static_cast<WICDecodeOptions>(4))};
+        const auto result{codec_factory_.create_decoder()->Initialize(stream.get(), static_cast<WICDecodeOptions>(4))};
 
         // Cache options is not used by decoder and by design not validated.
         Assert::AreEqual(error_ok, result);
@@ -242,7 +243,7 @@ public:
 
     TEST_METHOD(Initialize_null_stream) // NOLINT
     {
-        const auto result{factory_.create_decoder()->Initialize(nullptr, WICDecodeMetadataCacheOnDemand)};
+        const auto result{codec_factory_.create_decoder()->Initialize(nullptr, WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_invalid_argument, result);
     }
 
@@ -252,7 +253,7 @@ public:
         check_hresult(
             SHCreateStreamOnFileEx(L"tulips-gray-8bit-512-512.pgm", STGM_READ | STGM_SHARE_DENY_WRITE, 0, false, nullptr, stream.put()));
 
-        com_ptr<IWICBitmapDecoder> decoder = factory_.create_decoder();
+        com_ptr<IWICBitmapDecoder> decoder = codec_factory_.create_decoder();
         auto result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_ok, result);
 
@@ -273,7 +274,7 @@ public:
         check_hresult(
             SHCreateStreamOnFileEx(L"tulips-gray-8bit-512-512.pgm", STGM_READ | STGM_SHARE_DENY_WRITE, 0, false, nullptr, stream.put()));
 
-        com_ptr<IWICBitmapDecoder> decoder = factory_.create_decoder();
+        com_ptr<IWICBitmapDecoder> decoder = codec_factory_.create_decoder();
         auto result{decoder->Initialize(stream.get(), WICDecodeMetadataCacheOnDemand)};
         Assert::AreEqual(error_ok, result);
 
@@ -286,7 +287,7 @@ public:
     TEST_METHOD(GetFrame_with_bad_index) // NOLINT
     {
         com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
-        const auto result{factory_.create_decoder()->GetFrame(1, bitmap_frame_decode.put())};
+        const auto result{codec_factory_.create_decoder()->GetFrame(1, bitmap_frame_decode.put())};
 
         Assert::AreEqual(wincodec::error_frame_missing, result);
     }
@@ -294,11 +295,11 @@ public:
     TEST_METHOD(GetFrame_not_initialized) // NOLINT
     {
         com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
-        const auto result{factory_.create_decoder()->GetFrame(0, bitmap_frame_decode.put())};
+        const auto result{codec_factory_.create_decoder()->GetFrame(0, bitmap_frame_decode.put())};
 
         Assert::AreEqual(wincodec::error_not_initialized, result);
     }
 
 private:
-    factory factory_;
+    codec_factory codec_factory_;
 };

--- a/test/netpbm_bitmap_frame_decode_test.cpp
+++ b/test/netpbm_bitmap_frame_decode_test.cpp
@@ -1,15 +1,16 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
-#include "util.hpp"
+#include "macros.hpp"
+#include "cpp_unit_test.hpp"
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import test.winrt;
 
 import test.errors;
 import portable_anymap_file;
-import factory;
+import codec_factory;
 
 using std::array;
 using std::span;
@@ -478,5 +479,5 @@ private:
         }
     }
 
-    factory factory_;
+    codec_factory factory_;
 };

--- a/test/pnm_header_test.cpp
+++ b/test/pnm_header_test.cpp
@@ -1,10 +1,10 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "cpp_unit_test.hpp"
 
 import std;
-import <win.h>;
+import <win.hpp>;
 import test.winrt;
 
 import pnm_header;

--- a/test/portable_anymap_file.ixx
+++ b/test/portable_anymap_file.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 export module portable_anymap_file;
 
@@ -18,7 +18,7 @@ constexpr int32_t log_2(const int32_t n) noexcept
     {
         ++x;
     }
-    return x; 
+    return x;
 }
 
 } // namespace

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -105,7 +105,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <AdditionalModuleDependencies>$(IntDir)../netpbm-wic-codec/pnm_header.ixx.ifc</AdditionalModuleDependencies>
       <AdditionalBMIDirectories>$(IntDir)../netpbm-wic-codec/</AdditionalBMIDirectories>
@@ -114,7 +113,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <AdditionalModuleDependencies>$(IntDir)../netpbm-wic-codec/pnm_header.ixx.ifc</AdditionalModuleDependencies>
       <AdditionalBMIDirectories>$(IntDir)../netpbm-wic-codec/</AdditionalBMIDirectories>
@@ -122,7 +120,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <AdditionalModuleDependencies>$(IntDir)../netpbm-wic-codec/pnm_header.ixx.ifc</AdditionalModuleDependencies>
     </ClCompile>
@@ -176,13 +173,13 @@
     <ClCompile Include="portable_anymap_file.ixx" />
     <ClCompile Include="test_stream.ixx" />
     <ClCompile Include="test_util.ixx" />
-    <ClCompile Include="factory.ixx" />
+    <ClCompile Include="codec_factory.ixx" />
     <ClCompile Include="test_winrt.ixx" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cpp_unit_test.hpp" />
     <ClInclude Include="intellisense.hpp" />
-    <ClInclude Include="util.hpp" />
+    <ClInclude Include="macros.hpp" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="data-files\2bit_4x1.pgm">

--- a/test/test.vcxproj.filters
+++ b/test/test.vcxproj.filters
@@ -39,7 +39,7 @@
     <ClCompile Include="test_util.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="factory.ixx">
+    <ClCompile Include="codec_factory.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="test_winrt.ixx">
@@ -50,7 +50,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="util.hpp">
+    <ClInclude Include="macros.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="cpp_unit_test.hpp">

--- a/test/test_errors.ixx
+++ b/test/test_errors.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
@@ -7,7 +7,7 @@ module;
 
 export module test.errors;
 
-import <win.h>;
+import <win.hpp>;
 
 export {
 

--- a/test/test_stream.ixx
+++ b/test/test_stream.ixx
@@ -1,21 +1,20 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 
-#include "util.hpp"
 #include "intellisense.hpp"
 
 export module test.stream;
 
-import <win.h>;
+import <win.hpp>;
 import test.winrt;
 
 import test.errors;
 
 export struct test_stream : winrt::implements<test_stream, IStream>
 {
-    test_stream(const bool fail_on_read, int fail_on_seek_counter) noexcept :
+    test_stream(const bool fail_on_read, const int fail_on_seek_counter) noexcept :
         fail_on_read_{fail_on_read}, fail_on_seek_counter_{fail_on_seek_counter}
     {
     }
@@ -24,7 +23,7 @@ export struct test_stream : winrt::implements<test_stream, IStream>
                            _Out_opt_ ULONG* pcbRead) noexcept override
     {
         if (pcbRead)
-            pcbRead = 0;
+            *pcbRead = 0;
 
         return fail_on_read_ ? error_fail : error_ok;
     }
@@ -35,11 +34,11 @@ export struct test_stream : winrt::implements<test_stream, IStream>
         return error_fail;
     }
 
-    HRESULT __stdcall Seek(LARGE_INTEGER, DWORD /*dwOrigin*/, _Out_opt_ ULARGE_INTEGER* plibNewPosition) override
+    HRESULT __stdcall Seek(LARGE_INTEGER, DWORD /*dwOrigin*/, _Out_opt_ ULARGE_INTEGER* libNewPosition) override
     {
         --fail_on_seek_counter_;
-        if (plibNewPosition)
-            plibNewPosition->QuadPart = 0L;
+        if (libNewPosition)
+            libNewPosition->QuadPart = 0L;
 
         return fail_on_seek_counter_ <= 0 ? error_fail : error_ok;
     }

--- a/test/test_util.ixx
+++ b/test/test_util.ixx
@@ -1,10 +1,10 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 export module test.util;
 
 import std;
-import <win.h>;
+import <win.hpp>;
 
 import test.winrt;
 

--- a/test/test_winrt.ixx
+++ b/test/test_winrt.ixx
@@ -1,5 +1,5 @@
-// Copyright (c) Victor Derks.
-// SPDX-License-Identifier: MIT
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
 
 module;
 


### PR DESCRIPTION
- Align the license with the other Team CharLS projects.
- Use .hpp for all header files
- Rename factory into codec_factory
- Fix some ReSharper warnings