### PR TITLE
Add .cmd to sign the WIC DLL and installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+## [0.2.0 - 2024-10-8]
+
+### Added
+
+- Initial release.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,6 +35,11 @@
 
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio><!-- Enable faster builds for SDK style projects in Visual Studio 2022 17.5 and newer. -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+    <_CertificateThumbprint>$(CertificateThumbprint)</_CertificateThumbprint>
+    <_CertificateThumbprint Condition="'$(_CertificateThumbprint)' == ''">b834c6c1d7e0ae8e76cadcf9e2e7a273133a5df6</_CertificateThumbprint>
+    <_TimestampUrl>$(TimestampUrl)</_TimestampUrl>
+    <_TimestampUrl Condition="'$(_TimestampUrl)' == ''">http://time.certum.pl/</_TimestampUrl>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Go to the [releases](https://github.com/team-charls/netpbm-wic-codec/releases) p
 Assets at the bottom to show the files available in the release.
 Please use the appropriate installer that matches your machine's architecture.
 
-### Applications that can use the Netpbm WIC codec
+## Applications that can use the Netpbm WIC codec
 
 The following application have been validated to work with the Netpbm WIC codec:
 
@@ -123,3 +123,16 @@ regsvr32 netpbm-wic-codec.dll
 ```shell
 regsvr32 -u netpbm-wic-codec.dll
 ```
+
+### Building and code signing
+
+A command file is available to build and sign the WIC DLL and the setup application.  
+Instructions:
+
+* Open a Visual Studio Developer Command Prompt
+* Go the root of the cloned repository
+* Ensure a code signing certificate is available
+* Execute the command `create-signed-builds.cmd certificate-thumb-print time-stamp-url`  
+ Note: the certificate thumbprint and time stamp URL arguments are depending on the used code signing certificate.
+
+ The WIC DLL and the installer will be signed for the release builds of x86, x64 and ARM64.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.0   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Security issues should be reported privately by creating a security advisory on GitHub.
+
+Please do not open a public issue for anything you think might have a security implication.

--- a/create-signed-builds.cmd
+++ b/create-signed-builds.cmd
@@ -1,0 +1,15 @@
+# Build signed x86
+msbuild -t:clean -p:Configuration=Release -p:Platform=x86
+msbuild -t:restore -p:Configuration=Release -p:Platform=x86
+msbuild -t:build -p:Configuration=Release -p:Platform=x86 -p:SignOutput=true -p:CertificateThumbprint=%1 -p:TimestampUrl=%2
+
+# Build signed x64
+msbuild -t:clean -p:Configuration=Release -p:Platform=x64
+msbuild -t:restore -p:Configuration=Release -p:Platform=x64
+msbuild -t:build -p:Configuration=Release -p:Platform=x64 -p:SignOutput=true -p:CertificateThumbprint=%1 -p:TimestampUrl=%2
+
+# Build signed ARM64
+msbuild -t:clean -p:Configuration=Release -p:Platform=ARM64
+msbuild -t:restore -p:Configuration=Release -p:Platform=ARM64
+msbuild -t:build -p:Configuration=Release -p:Platform=ARM64 -p:SignOutput=true -p:CertificateThumbprint=%1 -p:TimestampUrl=%2
+

--- a/setup/bootstrapper/bootstrapper.wixproj
+++ b/setup/bootstrapper/bootstrapper.wixproj
@@ -17,4 +17,14 @@
   <ItemGroup>
     <ProjectReference Include="..\installer\installer.wixproj" />
   </ItemGroup>
+
+  <Target Name="SignBundleEngine">
+    <Message Importance="high" Text="SignBundleEngine: @(SignBundleEngine)" />
+    <Exec Command='signtool.exe sign /fd SHA256 /td SHA256 /v /sha1 $(_CertificateThumbprint) /tr $(_TimestampUrl) "%(SignBundleEngine.FullPath)" ' />
+  </Target>
+
+  <Target Name="SignBundle">
+    <Message Importance="high" Text="SignBundle: @(SignBundle)" />
+    <Exec Command='signtool.exe sign /fd SHA256 /td SHA256 /v /sha1 $(_CertificateThumbprint) /tr $(_TimestampUrl) "%(SignBundle.FullPath)" ' />
+  </Target>
 </Project>

--- a/setup/installer/installer.wixproj
+++ b/setup/installer/installer.wixproj
@@ -12,4 +12,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\netpbm-wic-codec.vcxproj" />
   </ItemGroup>
+
+  <Target Name="SignMsi">
+    <Message Importance="high" Text="SignMsi: @(SignMsi)" />
+    <Exec Command='signtool.exe sign /fd SHA256 /td SHA256 /v /sha1 $(_CertificateThumbprint) /tr $(_TimestampUrl) "%(SignMsi.FullPath)" ' />
+  </Target>
 </Project>

--- a/src/netpbm-wic-codec.vcxproj
+++ b/src/netpbm-wic-codec.vcxproj
@@ -228,4 +228,9 @@
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
+  <Target Name="SignWindowsDlls" AfterTargets="Build" Condition="'$(SignOutput)'=='true'">
+    <!-- Use TargetFrameworkVersion=v4.5 to sign with SHA256 -->
+    <Message Text="Signing netpbm-wic-codec.dll" />
+    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath)netpbm-wic-codec.dll" TargetFrameworkVersion="v4.5" />
+  </Target>
 </Project>


### PR DESCRIPTION
To make it possible to code sign, extend the projects with signing targets. Provide a .cmd file to build and sign all release builds. The current setup supports certificates stored on a smart card.