### PR TITLE
Add custom action to installer to trigger SHChangeNotify

### DIFF
--- a/netpbm-wic-codec.sln
+++ b/netpbm-wic-codec.sln
@@ -24,6 +24,8 @@ Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "bootstrapper", "setup\boots
 EndProject
 Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "installer", "setup\installer\installer.wixproj", "{8A21B212-8135-4499-9E5D-A2B47E88E983}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "shell-change-notify-custom-action", "setup\shell-change-notify-custom-action\shell-change-notify-custom-action.vcxproj", "{7409D02B-A48B-4E54-B633-3C81BB3512AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -94,6 +96,18 @@ Global
 		{8A21B212-8135-4499-9E5D-A2B47E88E983}.Release|x64.Build.0 = Release|x64
 		{8A21B212-8135-4499-9E5D-A2B47E88E983}.Release|x86.ActiveCfg = Release|x86
 		{8A21B212-8135-4499-9E5D-A2B47E88E983}.Release|x86.Build.0 = Release|x86
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Debug|ARM64.Build.0 = Debug|ARM64
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Debug|x64.ActiveCfg = Debug|x64
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Debug|x64.Build.0 = Debug|x64
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Debug|x86.ActiveCfg = Debug|Win32
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Debug|x86.Build.0 = Debug|Win32
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Release|ARM64.ActiveCfg = Release|ARM64
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Release|ARM64.Build.0 = Release|ARM64
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Release|x64.ActiveCfg = Release|x64
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Release|x64.Build.0 = Release|x64
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Release|x86.ActiveCfg = Release|Win32
+		{7409D02B-A48B-4E54-B633-3C81BB3512AB}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/setup/installer/Package.wxs
+++ b/setup/installer/Package.wxs
@@ -7,9 +7,9 @@
 
   <!-- Use a different upgrade code for x86 to allow x86 and x64 versions to be installed side by side -->
   <?if $(sys.BUILDARCHSHORT) = "X86" ?>
-    <?define UpgradeCode = "9de723f9-3e9a-446a-bb07-cf48b4b06878" ?>
+  <?define UpgradeCode = "9de723f9-3e9a-446a-bb07-cf48b4b06878" ?>
   <?else?>
-    <?define UpgradeCode = "9de723f9-3e9a-446a-bb07-cf48b4b06879" ?>
+  <?define UpgradeCode = "9de723f9-3e9a-446a-bb07-cf48b4b06879" ?>
   <?endif?>
 
   <Package
@@ -23,5 +23,13 @@
     <Feature Id="Main">
       <ComponentGroupRef Id="CodecComponents" />
     </Feature>
+
+    <InstallExecuteSequence>
+      <Custom Action="SHChangeNotifyCustomAction" Before="InstallFinalize" />
+    </InstallExecuteSequence>
+
+    <Binary Id="SHChangeNotifyCustomActionDll" SourceFile="shell-change-notify-custom-action.dll" />
+    <CustomAction Id="SHChangeNotifyCustomAction" BinaryRef="SHChangeNotifyCustomActionDll"
+                  DllEntry="SHChangeNotifyCustomAction" Execute="deferred" HideTarget="no" Impersonate="no" />
   </Package>
 </Wix>

--- a/setup/installer/installer.wixproj
+++ b/setup/installer/installer.wixproj
@@ -11,10 +11,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\netpbm-wic-codec.vcxproj" />
+    <ProjectReference Include="..\shell-change-notify-custom-action\shell-change-notify-custom-action.vcxproj" />
   </ItemGroup>
 
   <Target Name="SignMsi">
     <Message Importance="high" Text="SignMsi: @(SignMsi)" />
-    <Exec Command='signtool.exe sign /fd SHA256 /td SHA256 /v /sha1 $(_CertificateThumbprint) /tr $(_TimestampUrl) "%(SignMsi.FullPath)" ' />
+    <Exec Command="signtool.exe sign /fd SHA256 /td SHA256 /v /sha1 $(_CertificateThumbprint) /tr $(_TimestampUrl) &quot;%(SignMsi.FullPath)&quot; " />
   </Target>
 </Project>

--- a/setup/shell-change-notify-custom-action/dll_main.cpp
+++ b/setup/shell-change-notify-custom-action/dll_main.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <Windows.h>
+#include <msiquery.h>
+#include <ShlObj.h>
+
+unsigned int __stdcall SHChangeNotifyCustomAction(MSIHANDLE /*install*/)
+{
+    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+
+    return ERROR_SUCCESS;
+}

--- a/setup/shell-change-notify-custom-action/shell-change-notify-custom-action.def
+++ b/setup/shell-change-notify-custom-action/shell-change-notify-custom-action.def
@@ -1,0 +1,5 @@
+; Copyright (c) Team CharLS.
+; SPDX-License-Identifier: BSD-3-Clause
+
+EXPORTS
+    SHChangeNotifyCustomAction

--- a/setup/shell-change-notify-custom-action/shell-change-notify-custom-action.vcxproj
+++ b/setup/shell-change-notify-custom-action/shell-change-notify-custom-action.vcxproj
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{7409d02b-a48b-4e54-b633-3c81bb3512ab}</ProjectGuid>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup>
+    <Link>
+      <ModuleDefinitionFile>shell-change-notify-custom-action.def</ModuleDefinitionFile>
+    </Link>
+    <ClCompile>
+      <ExceptionHandling>false</ExceptionHandling>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="dll_main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="shell-change-notify-custom-action.def" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/setup/shell-change-notify-custom-action/shell-change-notify-custom-action.vcxproj.filters
+++ b/setup/shell-change-notify-custom-action/shell-change-notify-custom-action.vcxproj.filters
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dll_main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="shell-change-notify-custom-action.def">
+      <Filter>Source Files</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -31,7 +31,6 @@
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{F2EA965E-98D3-41C6-90D1-3DE4837D1041}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>unittest</RootNamespace>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>


### PR DESCRIPTION
SHChangeNotify needs to be called after adding the registry registrations. Wix has no standard support for it (has been requested, but not on the active backlog). Add a custom action DLL that just calls SHChangeNotify.