### PR TITLE
Replace std::mutex with  std::atomic<bool> in property_store

### DIFF
--- a/cpp.hint
+++ b/cpp.hint
@@ -8,3 +8,4 @@
 #define SUPPRESS_WARNING_NEXT_LINE(x)
 #define SUPPRESS_FALSE_WARNING_C26447_NEXT_LINE
 #define SUPPRESS_WARNING_6387_INVALID_ARGUMENT_NEXT_LINE
+#define TRACE(fmt, ...) OutputDebugStringA(std::format(fmt __VA_OPT__(,) __VA_ARGS__).c_str())

--- a/src/hresults.ixx
+++ b/src/hresults.ixx
@@ -21,6 +21,7 @@ constexpr HRESULT error_class_not_available{CLASS_E_CLASSNOTAVAILABLE};
 constexpr HRESULT error_invalid_argument{E_INVALIDARG};
 constexpr HRESULT error_access_denied{STG_E_ACCESSDENIED};
 constexpr HRESULT error_out_of_memory{E_OUTOFMEMORY};
+constexpr HRESULT error_not_valid_state{E_NOT_VALID_STATE};
 
 namespace self_registration {
 

--- a/test/property_store_test.cpp
+++ b/test/property_store_test.cpp
@@ -23,7 +23,7 @@ public:
         DWORD count;
         const auto result{codec_factory_.create_property_store()->GetCount(&count)};
 
-        Assert::AreEqual(success_ok, result);
+        Assert::AreEqual(error_not_valid_state, result);
         Assert::AreEqual(0UL, count);
     }
 
@@ -190,7 +190,7 @@ public:
 
         PROPERTYKEY property_key;
         const auto result{property_store->GetAt(0, &property_key)};
-        Assert::AreEqual(error_invalid_argument, result);
+        Assert::AreEqual(error_not_valid_state, result);
     }
 
     TEST_METHOD(GetAt_nullptr)

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -51,7 +51,7 @@
     <ClCompile Include="dll_main_test.cpp" />
     <ClCompile Include="property_store_test.cpp" />
     <ClCompile Include="property_variant_test.cpp" />
-    <ClCompile Include="test_results.ixx" />
+    <ClCompile Include="test_hresults.ixx" />
     <ClCompile Include="netpbm_bitmap_decoder_test.cpp" />
     <ClCompile Include="netpbm_bitmap_frame_decode_test.cpp" />
     <ClCompile Include="pnm_header_test.cpp" />

--- a/test/test.vcxproj.filters
+++ b/test/test.vcxproj.filters
@@ -18,7 +18,7 @@
     <ClCompile Include="netpbm_bitmap_decoder_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="test_results.ixx">
+    <ClCompile Include="test_hresults.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="dll_main_test.cpp">

--- a/test/test_hresults.ixx
+++ b/test/test_hresults.ixx
@@ -20,6 +20,7 @@ constexpr HRESULT error_invalid_argument{E_INVALIDARG};
 constexpr HRESULT error_no_aggregation{CLASS_E_NOAGGREGATION};
 constexpr HRESULT error_class_not_available{CLASS_E_CLASSNOTAVAILABLE};
 constexpr HRESULT error_access_denied{STG_E_ACCESSDENIED};
+constexpr HRESULT error_not_valid_state{E_NOT_VALID_STATE};
 
 namespace wincodec {
 constexpr HRESULT error_palette_unavailable{WINCODEC_ERR_PALETTEUNAVAILABLE};


### PR DESCRIPTION
All calls to the property_store are just "read" calls. After initialization there is no mutex needed as "read" calls can be handled multi-threading safe.

Note: IInitializeWithStream::Initialize can only be called once according to the specification.