### PR TITLE
Fix SPDX attributes

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText = © 2024 Team CharLS
-# SPDX-License-Identifier = BSD-3-Clause
+# SPDX-FileCopyrightText: © 2024 Team CharLS
+# SPDX-License-Identifier: BSD-3-Clause
 
 # This is a configuration file for the reuse lint tool. It allows specifing license info
 # for files that cannot be extended with such info.


### PR DESCRIPTION
The local check and the CI would not fail, but the offical overview check does.