### PR TITLE
Use import "macros.hpp" instead of include "macros.hpp"

### DIFF
--- a/src/buffered_stream_reader.cpp
+++ b/src/buffered_stream_reader.cpp
@@ -3,7 +3,6 @@
 
 module;
 
-#include "macros.hpp"
 #include "intellisense.hpp"
 
 module buffered_stream_reader;
@@ -12,6 +11,7 @@ import <win.hpp>;
 
 import hresults;
 import util;
+import "macros.hpp";
 
 using std::uint32_t;
 

--- a/src/dll_main.cpp
+++ b/src/dll_main.cpp
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: © 2020 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "macros.hpp"
+#include "intellisense.hpp"
 #include "version.hpp"
 
 import std;
-import <win.hpp>;
 import winrt;
+import <win.hpp>;
 
 import netpbm_bitmap_decoder;
 import netpbm_bitmap_encoder;
@@ -15,6 +15,7 @@ import guids;
 import registry;
 import util;
 import property_store;
+import "macros.hpp";
 
 using std::array;
 using std::uint32_t;

--- a/src/intellisense.hpp
+++ b/src/intellisense.hpp
@@ -3,10 +3,10 @@
 
 #pragma once
 
-// Include explicit headers as workaround that IntelliSense (VS 2022 17.12)
-// and ReSharper (2024.2.5) fail to parse #import <win.hpp>
-#if defined(__INTELLISENSE__) || defined(__RESHARPER__)
-// ReSharper disable once CppInconsistentNaming
+// Note: 2 separate workarounds are used to make it easier to track the status of the respective issues.
+
+// Include explicit headers as workaround that IntelliSense (VS 2022 17.12) fails to parse #import <win.hpp>
+#if defined(__INTELLISENSE__)
 #define _AMD64_
 #include <combaseapi.h>
 #include <libloaderapi.h>
@@ -14,4 +14,14 @@
 #include <wincodec.h>
 #include <winreg.h>
 #include <propkey.h>
+#endif
+
+// Include explicit headers as workaround that ReSharper (2024.3.2) fails to parse #import <win.hpp>
+#if defined(__RESHARPER__)
+// ReSharper disable once CppInconsistentNaming
+#include <combaseapi.h>
+#include <propkey.h>
+#include <wincodec.h>
+
+#include "macros.hpp"
 #endif

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -5,8 +5,6 @@
 
 #include <cassert>
 
-#include "intellisense.hpp"
-
 #define SUPPRESS_WARNING_NEXT_LINE(x) \
     __pragma(warning(suppress \
                      : x)) // NOLINT(misc-macro-parentheses, bugprone-macro-parentheses, cppcoreguidelines-macro-usage)

--- a/src/netpbm_bitmap_decoder.cpp
+++ b/src/netpbm_bitmap_decoder.cpp
@@ -3,13 +3,13 @@
 
 module;
 
-#include "macros.hpp"
+#include "intellisense.hpp"
 
 module netpbm_bitmap_decoder;
 
 import std;
-import <win.hpp>;
 import winrt;
+import <win.hpp>;
 
 import class_factory;
 import hresults;
@@ -17,6 +17,7 @@ import pnm_header;
 import guids;
 import netpbm_bitmap_frame_decode;
 import util;
+import "macros.hpp";
 
 using std::scoped_lock;
 using std::uint32_t;

--- a/src/netpbm_bitmap_encoder.cpp
+++ b/src/netpbm_bitmap_encoder.cpp
@@ -3,18 +3,19 @@
 
 module;
 
-#include "macros.hpp"
+#include "intellisense.hpp"
 
 module netpbm_bitmap_encoder;
 
 import std;
-import <win.hpp>;
 import winrt;
+import <win.hpp>;
 
 import class_factory;
 import guids;
 import hresults;
 import util;
+import "macros.hpp";
 
 using std::vector;
 using winrt::check_hresult;

--- a/src/netpbm_bitmap_frame_decode.cpp
+++ b/src/netpbm_bitmap_frame_decode.cpp
@@ -3,18 +3,19 @@
 
 module;
 
-#include "macros.hpp"
+#include "intellisense.hpp"
 
 module netpbm_bitmap_frame_decode;
 
 import std;
-import <win.hpp>;
 import winrt;
+import <win.hpp>;
 
 import hresults;
 import buffered_stream_reader;
 import pnm_header;
 import util;
+import "macros.hpp";
 
 using std::int32_t;
 using std::span;

--- a/src/property_store.cpp
+++ b/src/property_store.cpp
@@ -3,13 +3,13 @@
 
 module;
 
-#include "macros.hpp"
+#include "intellisense.hpp"
 
 module property_store;
 
 import std;
-import <win.hpp>;
 import winrt;
+import <win.hpp>;
 
 import hresults;
 import util;
@@ -17,6 +17,7 @@ import buffered_stream_reader;
 import pnm_header;
 import class_factory;
 import property_variant;
+import "macros.hpp";
 
 using std::array;
 using std::pair;
@@ -29,13 +30,13 @@ namespace {
 
 template<typename Key, typename Value, size_t Extent>
 [[nodiscard]]
-const Value* find(span<const Key, Extent> keys, span<Value, Extent> values, const Key& key)
+const Value* find(span<const Key, Extent> keys, span<Value, Extent> values, const Key& key_to_find)
 {
     ASSERT(keys.size() == values.size());
 
     for (size_t i{}; i < keys.size(); ++i)
     {
-        if (keys[i] == key)
+        if (keys[i] == key_to_find)
         {
             return &values[i];
         }

--- a/src/property_variant.ixx
+++ b/src/property_variant.ixx
@@ -1,15 +1,13 @@
 // SPDX-FileCopyrightText: © 2021 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
-module;
-
-#include "macros.hpp"
-
 export module property_variant;
 
 import std;
-import <win.hpp>;
 import winrt;
+import <win.hpp>;
+
+import "macros.hpp";
 
 export struct property_variant final : PROPVARIANT
 {

--- a/src/registry.ixx
+++ b/src/registry.ixx
@@ -1,21 +1,19 @@
 // SPDX-FileCopyrightText: © 2020 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
-module;
-
-#include "macros.hpp"
-
 export module registry;
 
 import std;
+import winrt;
 import <win.hpp>;
 
 import hresults;
-import winrt;
+import "macros.hpp";
 
+using std::wstring;
 using winrt::check_win32;
 
-SUPPRESS_WARNING_NEXT_LINE(26493)                  // Don't use C-style casts
+SUPPRESS_WARNING_NEXT_LINE(26493)                  // Don't use C-style casts (used by macro HKEY_LOCAL_MACHINE)
 const HKEY hkey_local_machine{HKEY_LOCAL_MACHINE}; // NOLINT
 
 namespace registry {
@@ -28,18 +26,19 @@ export void set_value(_Null_terminated_ const wchar_t* sub_key, _Null_terminated
                                static_cast<DWORD>(length * sizeof(wchar_t)))); // NOLINT(bugprone-misplaced-widening-cast)
 }
 
-export inline void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar_t* value_name,
-                      _Null_terminated_ const wchar_t* value)
+export inline void set_value(const wstring& sub_key, _Null_terminated_ const wchar_t* value_name,
+                             _Null_terminated_ const wchar_t* value)
 {
     set_value(sub_key.c_str(), value_name, value);
 }
 
-export void set_value(_Null_terminated_ const wchar_t* sub_key, _Null_terminated_ const wchar_t* value_name, const std::uint32_t value)
+export void set_value(_Null_terminated_ const wchar_t* sub_key, _Null_terminated_ const wchar_t* value_name,
+                      const std::uint32_t value)
 {
     check_win32(RegSetKeyValue(hkey_local_machine, sub_key, value_name, REG_DWORD, &value, sizeof value));
 }
 
-export void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar_t* value_name, const std::uint32_t value)
+export void set_value(const wstring& sub_key, _Null_terminated_ const wchar_t* value_name, const std::uint32_t value)
 {
     set_value(sub_key.c_str(), value_name, value);
 }
@@ -51,13 +50,13 @@ export void set_value(_Null_terminated_ const wchar_t* sub_key, _Null_terminated
         RegSetKeyValue(hkey_local_machine, sub_key, value_name, REG_BINARY, value, static_cast<DWORD>(value_size_in_bytes)));
 }
 
-export void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar_t* value_name,
+export void set_value(const wstring& sub_key, _Null_terminated_ const wchar_t* value_name,
                       const std::span<const std::byte> value)
 {
     set_value(sub_key.c_str(), value_name, value.data(), value.size());
 }
 
-export void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar_t* value_name, const void* value,
+export void set_value(const wstring& sub_key, _Null_terminated_ const wchar_t* value_name, const void* value,
                       const size_t value_size_in_bytes)
 {
     set_value(sub_key.c_str(), value_name, value, value_size_in_bytes);
@@ -65,7 +64,7 @@ export void set_value(const std::wstring& sub_key, _Null_terminated_ const wchar
 
 export HRESULT delete_tree(_Null_terminated_ const wchar_t* sub_key) noexcept
 {
-    if (const LSTATUS result = RegDeleteTreeW(hkey_local_machine, sub_key); result != ERROR_SUCCESS)
+    if (const LSTATUS result{RegDeleteTreeW(hkey_local_machine, sub_key)}; result != ERROR_SUCCESS)
     {
         return HRESULT_FROM_WIN32(result);
     }

--- a/src/util.ixx
+++ b/src/util.ixx
@@ -1,17 +1,17 @@
 // SPDX-FileCopyrightText: © 2020 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
-module;
-
-#include "macros.hpp"
-
 export module util;
 
 import std;
-import <win.hpp>;
 import winrt;
+import <win.hpp>;
 
 import hresults;
+import "macros.hpp";
+
+using std::wstring;
+using winrt::hresult;
 
 namespace {
 
@@ -26,9 +26,9 @@ namespace {
 
 } // namespace
 
-export [[nodiscard]] std::wstring guid_to_string(const GUID& guid)
+export [[nodiscard]] wstring guid_to_string(const GUID& guid)
 {
-    std::wstring guid_text;
+    wstring guid_text;
 
     guid_text.resize(39);
     VERIFY(StringFromGUID2(guid, guid_text.data(), static_cast<int>(guid_text.size())) != 0);
@@ -39,9 +39,9 @@ export [[nodiscard]] std::wstring guid_to_string(const GUID& guid)
     return guid_text;
 }
 
-export [[nodiscard]] std::wstring get_module_path()
+export [[nodiscard]] wstring get_module_path()
 {
-    std::wstring path(100, L'?');
+    wstring path(100, L'?');
     size_t path_size;
     size_t actual_size;
 
@@ -68,13 +68,13 @@ export template<typename T>
     return std::bit_cast<const void*>(p);
 }
 
-export void inline check_hresult(const winrt::hresult result, const winrt::hresult result_to_throw)
+export void inline check_hresult(const hresult result, const hresult result_to_throw)
 {
     if (result < 0)
         throw_hresult(result_to_throw);
 }
 
-export [[nodiscard]] constexpr bool failed(const winrt::hresult result) noexcept
+export [[nodiscard]] constexpr bool failed(const hresult result) noexcept
 {
     return result < 0;
 }
@@ -97,7 +97,7 @@ T* check_out_pointer(T* pointer)
     return pointer;
 }
 
-export void check_condition(const bool condition, const winrt::hresult result_to_throw)
+export void check_condition(const bool condition, const hresult result_to_throw)
 {
     if (!condition)
         throw_hresult(result_to_throw);
@@ -117,4 +117,6 @@ export __declspec(noinline) HRESULT to_hresult() noexcept
     {
         return error_out_of_memory;
     }
+
+    // Explicitly don't catch other unexpected exceptions to trigger call to terminate with dump.
 }


### PR DESCRIPTION
Support for header units in Visual Studio 2022 17.12 is good enough to use header units for macros.hpp, use it in the main DLL. IntelliSense and ReSharper still need the workaround include file.